### PR TITLE
Add campfire support and signed avatar URLs to comments

### DIFF
--- a/components/campfires/campfire-creation-modal.tsx
+++ b/components/campfires/campfire-creation-modal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
@@ -127,6 +128,7 @@ const CreateCampfireModal = ({
   open,
   onOpenChange,
 }: CreateCampfireModalProps) => {
+  const router = useRouter();
   const [step, setStep] = useState(1);
   const [wordCount, setWordCount] = useState<number>(0);
 
@@ -161,12 +163,13 @@ const CreateCampfireModal = ({
 
   const handleFinalSubmit = async (data: FullFormType) => {
     const formData = new FormData();
+    const generatedSlug = generateCampfireSlug(data.name)
     formData.append('name', `x/${data.name}`);
     formData.append('description', data.description);
     formData.append('purpose', data.purpose);
     formData.append('visibility', data.visibility);
     formData.append('rules', JSON.stringify(rules));
-    formData.append('slug', generateCampfireSlug(data.name));
+    formData.append('slug', generatedSlug);
     
     if (iconBlob) {
       formData.append(
@@ -189,6 +192,7 @@ const CreateCampfireModal = ({
           form.reset();
           setStep(1);
           onOpenChange(false);
+          router.push(`/x/${generatedSlug}`);
         }
       },
     });

--- a/components/campfires/campfire-details.tsx
+++ b/components/campfires/campfire-details.tsx
@@ -184,8 +184,8 @@ const CampfireDetails = ({slug}: {slug : string}) => {
           <div className="relative w-full h-full">
           <Avatar className="hidden lg:flex rounded-full border-3 border-white dark:border-black/80 h-20 w-20">
               <AvatarImage className="rounded-full object-contain" src={campfire.iconURL || undefined} alt={campfire.name} />
-              <AvatarFallback className="border-lavender-500 flex h-8 w-8 items-center justify-center rounded-full border font-semibold text-white"><span
-                  className={`bg-lavender-500 flex h-7 w-7 items-center justify-center rounded-full font-semibold text-white`}
+              <AvatarFallback className="border-lavender-500 flex items-center justify-center rounded-full border font-semibold text-white"><span
+                  className={`bg-lavender-500 flex h-20 w-20 items-center justify-center rounded-full font-semibold text-white text-3xl`}
                 >
                   x/
                 </span></AvatarFallback>

--- a/components/campfires/campfire-feed-list.tsx
+++ b/components/campfires/campfire-feed-list.tsx
@@ -84,8 +84,7 @@ const CampfireFeedList = ({
 
   const handlePostClick = (postId: string) => {
     let viewContext = {};
-    if (isDesktop) {
-      if (!scrollableContainer) return;
+    if (isDesktop && scrollableContainer ) {
       viewContext = {
         scrollY: scrollableContainer.scrollTop,
         timestamp: Date.now(),
@@ -109,7 +108,7 @@ const CampfireFeedList = ({
         campfireId,
       };
     }
-
+    console.log("clicking")
     sessionStorage.setItem(`campfireFeedViewContext-${campfireId}`, JSON.stringify(viewContext));
     router.push(`/post/${postId}`);
   };

--- a/components/cards/CommentCard.tsx
+++ b/components/cards/CommentCard.tsx
@@ -24,6 +24,12 @@ interface CommentCardProps {
   className?: string;
   expandedComments?: Set<number>;
   postCreatedBy: string | null;
+  campfires?: {
+    name: string;
+    slug: string;
+    iconUrl?: string;
+  } | null
+  commentSignedUrls?: Record<string, string>;
 }
 
 const CommentCard = ({
@@ -38,6 +44,8 @@ const CommentCard = ({
   replyingTo,
   expandedComments,
   postCreatedBy,
+  campfires,
+  commentSignedUrls,
 }: CommentCardProps) => {
   // states
   const [isOpen, setIsOpen] = useState<boolean>(false);
@@ -50,6 +58,14 @@ const CommentCard = ({
   useEffect(() => {
     setTimestamp(format(comment.created_at));
   }, [comment]);
+
+  const displayName = campfires?.name || comment.author_name;
+
+  // Avatar source logic with campfire support
+  const avatarSrc = campfires?.iconUrl || 
+    (comment.author_avatar_url && commentSignedUrls?.[comment.author_avatar_url]) || 
+    comment.author_avatar_url || 
+    undefined;
 
   return (
     <>
@@ -103,14 +119,14 @@ const CommentCard = ({
           >
             <div className="flex items-center justify-center gap-1">
               <Avatar className="h-8 w-8">
-                <AvatarImage src={comment.author_avatar_url || undefined} />
+                <AvatarImage src={avatarSrc || undefined} />
                 <AvatarFallback className="bg-gradient-to-br from-[#0536ff] to-[#6a71ea] text-white">
-                  {comment.author_name?.slice(0, 2).toUpperCase()}
+                  {displayName?.slice(0, 2).toUpperCase()}
                 </AvatarFallback>
               </Avatar>
               <div className="flex flex-col items-start justify-center gap-1">
                 <h5 className="text-sm font-semibold tracking-tight text-gray-900 dark:text-white">
-                  {comment.author_name}
+                  {displayName}
                 </h5>
               </div>
               <small className="ml-2 text-xs text-zinc-500 dark:text-gray-400">

--- a/components/cards/CommentChart.tsx
+++ b/components/cards/CommentChart.tsx
@@ -2,7 +2,15 @@
 import React from 'react';
 import { NestedComment } from '@/types/global';
 import CommentCard from "@/components/cards/CommentCard";
+import { useCommentSignedUrls } from '@/hooks/storage/useCommentSignedUrl';
 
+/*
+{
+    "name": "x/Best Of Anime",
+    "slug": "best-of-anime",
+    "icon_url": "http://127.0.0.1:54321/storage/v1/object/public/campfires.bucket/icons/4a39dece-d3f4-47f7-8bd5-e667e9c8c5d6_icon_1754846924934"
+}
+*/
 interface CommentChartProps {
   comments: NestedComment[];
   onReply: (authorName: string, commentId: number) => void;
@@ -10,9 +18,14 @@ interface CommentChartProps {
   expandedComments: Set<number>;
   onToggleExpanded: (commentId: number) => void;
   postCreatedBy: string | null;
+  campfires?: {
+    name: string;
+    slug: string;
+    iconUrl?: string;
+  } | null
 }
 
-const CommentChart: React.FC<CommentChartProps> = ({ comments, onReply, replyingTo, expandedComments, onToggleExpanded, postCreatedBy }) => {
+const CommentChart: React.FC<CommentChartProps> = ({ comments, onReply, replyingTo, expandedComments, onToggleExpanded, postCreatedBy, campfires }) => {
   // const [expandedComments, setExpandedComments] = useState<Set<string>>(new Set());
 
   // const toggleExpanded = (commentId: number) => {
@@ -66,6 +79,7 @@ const CommentChart: React.FC<CommentChartProps> = ({ comments, onReply, replying
   //   );
   // };
 
+  const { data: commentSignedUrls } = useCommentSignedUrls(comments);
   return (
     <div className="space-y-2 ">
       {/* {rootComments.map((comment) => renderComment(comment, 0))} */}
@@ -80,6 +94,8 @@ const CommentChart: React.FC<CommentChartProps> = ({ comments, onReply, replying
                     onToggleExpanded={onToggleExpanded}
                     expandedComments={expandedComments}
                     postCreatedBy={postCreatedBy}
+                    campfires={campfires}
+                    commentSignedUrls={commentSignedUrls}
                 />
             ))}
     </div>

--- a/components/ui/PostDetailDrawer.tsx
+++ b/components/ui/PostDetailDrawer.tsx
@@ -134,6 +134,7 @@ const PostDetailDrawer = ({ post, type }: { post: DetailPost; type: Type }) => {
         parentId,
         depth,
         parentAuthorId,
+        campfireId: post.campfire_id,
       },
       {
         onSuccess: () => {

--- a/hooks/posts/useCommentMutation.ts
+++ b/hooks/posts/useCommentMutation.ts
@@ -14,6 +14,7 @@ interface CreateCommentVariables {
   parentId?: number;
   depth?: number;
   parentAuthorId? : string;
+  campfireId?: string | null;
 }
 
 interface CreateCommentContext {
@@ -31,7 +32,7 @@ export function useCommentMutation(post: DetailPost) {
     CreateCommentVariables, // Variables passed to the mutation function
     CreateCommentContext // Context type for onMutate/onError
   >({
-    mutationFn: async ({ postId, commentText, parentId , depth, parentAuthorId  }) => {
+    mutationFn: async ({ postId, commentText, parentId , depth, parentAuthorId, campfireId  }) => {
       if (!user?.id) {
         throw new Error('User not authenticated');
       }
@@ -43,6 +44,7 @@ export function useCommentMutation(post: DetailPost) {
           comment_text: commentText,
           parent_id: parentId ? Number(parentId) : null,
           depth: depth ? depth : 0,
+          campfire_id: campfireId,
         })
         .select()
         .single();

--- a/hooks/storage/useCommentSignedUrl.ts
+++ b/hooks/storage/useCommentSignedUrl.ts
@@ -1,0 +1,39 @@
+// hooks/storage/useSignedUrls.ts
+import {useMemo} from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+import { getBatchSignedUrls } from '@/lib/actions/storage.actions';
+import { Comment, NestedComment } from '@/types/global';
+
+/**
+ * A React Query hook to efficiently fetch a batch of signed URLs for post avatars.
+ * @param comments - The array of comments from the initial feed query.
+ * @returns The result of the React Query operation, containing a map of avatar paths to signed URLs.
+ */
+export const useCommentSignedUrls = (comments: Comment[] | NestedComment[] | undefined) => {
+  // 1. Extract only the avatar paths that need a signed URL
+  const avatarPaths = useMemo(() => {
+    if (!comments) return [];
+
+    return comments
+      .filter(
+        comment =>
+          // Check if the author is a professional AND the URL is a path, not a full http URL
+          comment.author_avatar_url &&
+          !comment.author_avatar_url.startsWith('http'),
+      )
+      .map(comment => comment.author_avatar_url!); // The '!' is safe due to the filter
+  }, [comments]);
+
+  // 2. Use React Query to fetch the URLs in a batch
+  return useQuery({
+    queryKey: ['commentSignedUrls', avatarPaths],
+    queryFn: () => getBatchSignedUrls(avatarPaths),
+    // Only run the query if there are actually paths to fetch
+    enabled: avatarPaths.length > 0,
+    // Keep the data fresh for 55 minutes to avoid re-fetching URLs that are valid for 60 mins
+    staleTime: 1000 * 60 * 55,
+    // Avoid refetching on window focus, as the URLs are long-lived
+    refetchOnWindowFocus: false,
+  });
+};


### PR DESCRIPTION
Introduces campfire metadata to comment components and enables support for signed avatar URLs via a new useCommentSignedUrls hook. Updates CommentCard and CommentChart to display campfire icons and names, and passes campfireId when creating comments. This improves avatar security and allows comments to be associated with campfires.