### PR TITLE
Add daily prompt question display on feed card

### DIFF
--- a/app/(protected)/create-post/page.tsx
+++ b/app/(protected)/create-post/page.tsx
@@ -11,11 +11,21 @@ export const metadata: Metadata = {
   description: "Create and share your story with a caring community offering support, advice, and encouragement for mental wellness and personal growth."
 };
 
-const CreatePost = () => {
+type SearchParams = Promise<{ [key: string]: string | undefined }>
+
+const CreatePost = async (props: {
+  searchParams: SearchParams
+}) => {
+
+  const searchParams = await props.searchParams;
+  const submit = searchParams.submit;
+  const prompt = searchParams.prompt;
+  const prompt_id = searchParams.prompt_id;
+
   return (
     <TourProvider steps={createPostSteps}>
       <div className="container-spacing w-full">
-        <PostForm />
+        <PostForm submitToSlug={submit} promptTextQuery={prompt} promptIdQuery={prompt_id} />
 
         <div className="fixed bottom-10 right-6 z-50 block rounded-full">
           <TourButton />

--- a/components/cards/FeedEnhancedPostCard.tsx
+++ b/components/cards/FeedEnhancedPostCard.tsx
@@ -291,7 +291,7 @@ export function FeedEnhancedPostCard({
             postId={post.id}
             postCreatedBy={post.created_by ?? ""}
             onOpenChange={setIsOpen}
-            dailyPrompt={"Share the pettiest thing you’ve done out of spite."} //Replace with post.dailyPrompt
+            dailyPrompt={post.prompt_text} 
             showDailyPrompt={showDailyPrompt}
             setDailyPrompt={setShowDailyPrompt}
           />
@@ -302,14 +302,14 @@ export function FeedEnhancedPostCard({
             <SinglePost
               content={truncateText(post.content, 200)}
               onClick={onClick}
-              dailyPrompt={"Share the pettiest thing you’ve done out of spite."} //Replace with post.dailyPrompt
+              dailyPrompt={post.prompt_text}
               showDailyPrompt={showDailyPrompt}
             />
           ) : (
             <SimpleCarouselPost
               slides={post.post_slides || []}
               onClick={onClick}
-              dailyPrompt={"Share the pettiest thing you’ve done out of spite."} //Replace with post.dailyPrompt
+              dailyPrompt={post.prompt_text} //Replace with post.dailyPrompt
               showDailyPrompt={showDailyPrompt}
             />
           )}

--- a/components/cards/FeedEnhancedPostCard.tsx
+++ b/components/cards/FeedEnhancedPostCard.tsx
@@ -146,6 +146,8 @@ export function FeedEnhancedPostCard({
   // States
   const [timestamp, setTimestamp] = useState('');
   const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [showDailyPrompt, setShowDailyPrompt] = useState(false);
+
 
   // Register the custom locale
   register('short-en', customLocale);
@@ -289,14 +291,27 @@ export function FeedEnhancedPostCard({
             postId={post.id}
             postCreatedBy={post.created_by ?? ""}
             onOpenChange={setIsOpen}
+            dailyPrompt={"Share the pettiest thing you’ve done out of spite."} //Replace with post.dailyPrompt
+            showDailyPrompt={showDailyPrompt}
+            setDailyPrompt={setShowDailyPrompt}
           />
         </CardHeader>
 
         <CardContent className="cursor-pointer">
           {post.type === "single" ? (
-            <SinglePost content={truncateText(post.content, 200)} onClick={onClick} />
+            <SinglePost
+              content={truncateText(post.content, 200)}
+              onClick={onClick}
+              dailyPrompt={"Share the pettiest thing you’ve done out of spite."} //Replace with post.dailyPrompt
+              showDailyPrompt={showDailyPrompt}
+            />
           ) : (
-            <SimpleCarouselPost slides={post.post_slides || []} onClick={onClick} />
+            <SimpleCarouselPost
+              slides={post.post_slides || []}
+              onClick={onClick}
+              dailyPrompt={"Share the pettiest thing you’ve done out of spite."} //Replace with post.dailyPrompt
+              showDailyPrompt={showDailyPrompt}
+            />
           )}
           <div className="mt-2 flex flex-wrap gap-2">
             {post.posttags &&

--- a/components/shared/DailyPrompt.tsx
+++ b/components/shared/DailyPrompt.tsx
@@ -7,7 +7,7 @@ import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Card } from '@/components/ui/card';
-import { ArrowRight, Sparkles, CalendarDays, Tag } from 'lucide-react';
+import { ArrowRight, Sparkles, CalendarDays, Tag, HelpCircle } from 'lucide-react';
 import { usePreferencesStore } from '@/lib/store/preferences-store';
 import { motion } from 'motion/react';
 import qs from 'query-string';
@@ -279,3 +279,13 @@ const DailyPrompt = () => {
 };
 
 export default DailyPrompt;
+
+// Component to display the daily prompt question on a feed card
+export const DailyPromptQuestion = ( {dailyPrompt}:{dailyPrompt: string}) => {
+  return (
+    <div className="mb-1 flex items-start gap-1 text-sm text-gray-500 dark:text-gray-400 italic select-none">
+      <HelpCircle size={16}/>
+      <p>{dailyPrompt}</p>
+    </div>
+  )
+}

--- a/components/shared/PostDropdown.tsx
+++ b/components/shared/PostDropdown.tsx
@@ -27,7 +27,7 @@ type DropdownMenuProp = {
   commentCreatedBy?: string | number;
   commentPinnedStatus?: string;
   onOpenChange: React.Dispatch<React.SetStateAction<boolean>>;
-  dailyPrompt?: string;
+  dailyPrompt?: string | null;
   setDailyPrompt?: React.Dispatch<React.SetStateAction<boolean>>;
   showDailyPrompt?: boolean;
 };

--- a/components/shared/PostDropdown.tsx
+++ b/components/shared/PostDropdown.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useUserState } from '@/lib/store/user';
-import { Trash2, Telescope, Flag, Pin } from 'lucide-react';
+import {Trash2, Telescope, Flag, Pin, Eye, EyeOff} from 'lucide-react';
 import { usePostMutations } from '@/hooks/posts/usePostMutation';
 import { usePinComment } from '@/hooks/posts/usePinComment';
 
@@ -27,6 +27,9 @@ type DropdownMenuProp = {
   commentCreatedBy?: string | number;
   commentPinnedStatus?: string;
   onOpenChange: React.Dispatch<React.SetStateAction<boolean>>;
+  dailyPrompt?: string;
+  setDailyPrompt?: React.Dispatch<React.SetStateAction<boolean>>;
+  showDailyPrompt?: boolean;
 };
 
 const PostDropdown: React.FC<DropdownMenuProp> = ({
@@ -40,6 +43,9 @@ const PostDropdown: React.FC<DropdownMenuProp> = ({
   onOpenChange,
   content,
   commentPinnedStatus,
+  dailyPrompt,
+  setDailyPrompt,
+  showDailyPrompt
 }) => {
   const router = useRouter();
   const user = useUserState(state => state.user);
@@ -59,6 +65,15 @@ const PostDropdown: React.FC<DropdownMenuProp> = ({
   const handleReportClick = () => {
     onOpenChange(true);
   };
+
+  // Handle view daily prompt
+  // inside PostDropdown
+  const handleShowPrompt = () => {
+    if (setDailyPrompt) {
+      setDailyPrompt(prev => !prev)
+    }
+  }
+
 
   // check if user is author of the comment
   const isCommentAuthor = commentCreatedBy === user?.id;
@@ -166,6 +181,26 @@ const PostDropdown: React.FC<DropdownMenuProp> = ({
               <Link href={`post/${postId}`}>View</Link>
             </DropdownMenuItem>
           )}
+
+          {dailyPrompt && (
+            <DropdownMenuItem
+              className="hover:cursor-pointer"
+              onSelect={handleShowPrompt}
+            >
+              {showDailyPrompt ? (
+                <>
+                  <EyeOff size={16} strokeWidth={1.5} />
+                  <p>Hide prompt</p>
+                </>
+              ) : (
+                <>
+                  <Eye size={16} strokeWidth={1.5} />
+                  <p>Related Prompt</p>
+                </>
+              )}
+            </DropdownMenuItem>
+          )}
+
 
           <DropdownMenuItem
             className="hover:cursor-pointer"

--- a/components/shared/SinglePost.tsx
+++ b/components/shared/SinglePost.tsx
@@ -5,7 +5,7 @@ interface SinglePostProps {
     content: string
     onClick?: () => void,
     showDailyPrompt?: boolean,
-    dailyPrompt?: string
+    dailyPrompt?: string | null
   }
   
   export function SinglePost({ content, onClick,showDailyPrompt, dailyPrompt }: SinglePostProps) {

--- a/components/shared/SinglePost.tsx
+++ b/components/shared/SinglePost.tsx
@@ -1,15 +1,23 @@
+import {HelpCircle} from "lucide-react";
+import {DailyPromptQuestion} from "@/components/shared/DailyPrompt";
+
 interface SinglePostProps {
     content: string
-    onClick?: () => void
+    onClick?: () => void,
+    showDailyPrompt?: boolean,
+    dailyPrompt?: string
   }
   
-  export function SinglePost({ content, onClick }: SinglePostProps) {
+  export function SinglePost({ content, onClick,showDailyPrompt, dailyPrompt }: SinglePostProps) {
     return (
       <div className="relative" onClick={onClick}>
         <div className="bg-transparent  rounded-2xl py-2 ">
+          {showDailyPrompt && dailyPrompt && (
+            <DailyPromptQuestion dailyPrompt={dailyPrompt}/>
+          )}
           <p className="dark:text-white leading-relaxed text-content-label whitespace-pre-wrap active:text-lavender-400">{content}</p>
         </div>
-  
+
         {/* Decorative elements */}
         {/* <div className="absolute -top-2 -left-2 w-3 h-3 bg-gradient-to-br from-purple-400 to-pink-400 rounded-full opacity-60"></div>
         <div className="absolute -bottom-2 -right-1 w-3 h-3 bg-gradient-to-br from-blue-400 to-teal-400 rounded-full opacity-60"></div> */}

--- a/components/shared/Tour/SimpleCorouselPost.tsx
+++ b/components/shared/Tour/SimpleCorouselPost.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft, ArrowRight } from 'lucide-react';
 import { truncateText } from '@/lib/utils';
+import {DailyPromptQuestion} from "@/components/shared/DailyPrompt";
 
 interface Slide {
   content: string;
@@ -11,9 +12,11 @@ interface Slide {
 interface SimpleCarouselPostProps {
   slides: Slide[];
   onClick?: () => void;
+  showDailyPrompt?: boolean,
+  dailyPrompt?: string
 }
 
-const SimpleCarouselPost = ({ slides, onClick }: SimpleCarouselPostProps) => {
+const SimpleCarouselPost = ({ slides, onClick, showDailyPrompt, dailyPrompt }: SimpleCarouselPostProps) => {
   const [currentSlide, setCurrentSlide] = useState(0);
 
   const navigateSlide = (direction: 'prev' | 'next') => {
@@ -64,6 +67,9 @@ const SimpleCarouselPost = ({ slides, onClick }: SimpleCarouselPostProps) => {
 
       {/* Carousel Content */}
       <div className="mb-3 cursor-pointer" onClick={onClick}>
+        {showDailyPrompt && dailyPrompt && (
+          <DailyPromptQuestion dailyPrompt={dailyPrompt}/>
+        )}
         <p className="text-foreground leading-relaxed whitespace-pre-wrap text-content-label">
           {truncateText(slides[currentSlide]?.content || '', 200)}
         </p>

--- a/components/shared/Tour/SimpleCorouselPost.tsx
+++ b/components/shared/Tour/SimpleCorouselPost.tsx
@@ -13,7 +13,7 @@ interface SimpleCarouselPostProps {
   slides: Slide[];
   onClick?: () => void;
   showDailyPrompt?: boolean,
-  dailyPrompt?: string
+  dailyPrompt?: string | null
 }
 
 const SimpleCarouselPost = ({ slides, onClick, showDailyPrompt, dailyPrompt }: SimpleCarouselPostProps) => {

--- a/hooks/posts/useCommentMutation.ts
+++ b/hooks/posts/useCommentMutation.ts
@@ -109,6 +109,7 @@ export function useCommentMutation(post: DetailPost) {
         depth: depth ? depth : 0,
         parent_id: parentId ? Number(parentId) : null,
         pinned_status: 'none',
+        campfire_id: post.campfire_id,
       };
 
       // Optimistically update the comments list

--- a/queries/posts/getEnhancedFeed.ts
+++ b/queries/posts/getEnhancedFeed.ts
@@ -30,6 +30,8 @@ export interface EnhancedPost {
   views_count: number;
   collections: Array<{ user_id: string }>;
   post_slides: Array<{ slide_index: number; content: string }>;
+  prompt_text: string | null;
+  prompt_category: string | null;
 }
 
 interface FeedPage {

--- a/supabase/migrations/20250820182853_update-posts-table.sql
+++ b/supabase/migrations/20250820182853_update-posts-table.sql
@@ -1,0 +1,367 @@
+drop function if exists "public"."get_personalized_feed"(user_id_param uuid, page_size integer, offset_param integer);
+
+alter table "public"."posts" add column "daily_prompt_id" uuid;
+
+alter table "public"."posts" add constraint "posts_daily_prompt_id_fkey" FOREIGN KEY (daily_prompt_id) REFERENCES daily_prompts(id) ON UPDATE CASCADE ON DELETE SET NULL not valid;
+
+alter table "public"."posts" validate constraint "posts_daily_prompt_id_fkey";
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.get_personalized_feed_v1(user_id_param uuid, page_size integer DEFAULT 50, offset_param integer DEFAULT 0)
+ RETURNS TABLE(id uuid, created_at timestamp with time zone, created_by uuid, author_name text, content text, mood post_mood, author_avatar_url text, expires_in_24hr boolean, duration post_duration, expires_at timestamp with time zone, downvotes integer, upvotes integer, is_sensitive boolean, is_prompt_response boolean, type post_type, author_roles user_role[], campfire_id uuid, campfire_name text, campfire_slug text, campfire_icon_url text, priority_score integer, is_new_post boolean, is_campfire_post boolean, posttags jsonb, comments_count bigint, views_count bigint, collections jsonb, post_slides jsonb)
+ LANGUAGE plpgsql
+ SET search_path TO 'public'
+AS $function$DECLARE
+  new_post_threshold TIMESTAMPTZ := NOW() - INTERVAL '48 hours';
+BEGIN
+  RETURN QUERY
+  WITH user_campfires AS (
+    SELECT cm.campfire_id
+    FROM campfire_members cm
+    WHERE cm.user_id = user_id_param
+  ),
+  prioritized_posts AS (
+    SELECT
+      p.id,
+      p.created_at,
+      p.created_by,
+      p.author_name,
+      p.content,
+      p.mood,
+      p.author_avatar_url,
+      p.expires_in_24hr,
+      p.duration,
+      p.expires_at,
+      p.downvotes,
+      p.upvotes,
+      p.is_sensitive,
+      p.is_prompt_response,
+      p.type,
+      p.author_roles,
+      p.campfire_id,
+      c.name AS campfire_name,
+      c.slug AS campfire_slug,
+      c.icon_url AS campfire_icon_url,
+      CASE
+        WHEN p.created_at >= new_post_threshold THEN 1
+        WHEN p.campfire_id IS NOT NULL THEN 2
+        ELSE 3
+      END AS priority_score,
+      (p.created_at >= new_post_threshold) AS is_new_post,
+      (p.campfire_id IS NOT NULL) AS is_campfire_post
+    FROM posts p
+    LEFT JOIN campfires c ON p.campfire_id = c.id
+    WHERE
+      (
+        p.campfire_id IS NULL
+        OR p.campfire_id IN (SELECT uc.campfire_id FROM user_campfires uc)
+      )
+      AND (p.expires_at IS NULL OR p.expires_at > NOW())
+  ),
+  posts_with_aggregates AS (
+    SELECT
+      pp.id,
+      pp.created_at,
+      pp.created_by,
+      pp.author_name,
+      pp.content,
+      pp.mood,
+      pp.author_avatar_url,
+      pp.expires_in_24hr,
+      pp.duration,
+      pp.expires_at,
+      pp.downvotes,
+      pp.upvotes,
+      pp.is_sensitive,
+      pp.is_prompt_response,
+      pp.type,
+      pp.author_roles,
+      pp.campfire_id,
+      pp.campfire_name,
+      pp.campfire_slug,
+      pp.campfire_icon_url,
+      pp.priority_score,
+      pp.is_new_post,
+      pp.is_campfire_post,
+
+      -- Tags as JSONB
+      COALESCE(
+        (json_agg(
+          DISTINCT jsonb_build_object('name', t.name)
+        ) FILTER (WHERE t.name IS NOT NULL))::jsonb,
+        '[]'::jsonb
+      ) AS posttags,
+
+      -- Comment count
+      COALESCE(comments_agg.count, 0) AS comments_count,
+
+      -- View count
+      COALESCE(views_agg.count, 0) AS views_count,
+
+      -- Collections as JSONB
+      COALESCE(
+        (json_agg(
+          DISTINCT jsonb_build_object('user_id', col.user_id)
+        ) FILTER (WHERE col.user_id IS NOT NULL))::jsonb,
+        '[]'::jsonb
+      ) AS collections,
+
+      -- Post slides as JSONB
+      COALESCE(
+        (json_agg(
+          jsonb_build_object(
+            'slide_index', ps.slide_index,
+            'content', ps.content
+          ) ORDER BY ps.slide_index
+        ) FILTER (WHERE ps.slide_index IS NOT NULL))::jsonb,
+        '[]'::jsonb
+      ) AS post_slides
+
+    FROM prioritized_posts pp
+    LEFT JOIN posttags pt ON pp.id = pt.post
+    LEFT JOIN tags t ON pt.tag = t.id
+    LEFT JOIN (
+      SELECT post, COUNT(*) AS count
+      FROM comments
+      GROUP BY post
+    ) comments_agg ON pp.id = comments_agg.post
+    LEFT JOIN (
+      SELECT post_id, COUNT(*) AS count
+      FROM views
+      GROUP BY post_id
+    ) views_agg ON pp.id = views_agg.post_id
+    LEFT JOIN collections col ON pp.id = col.post_id
+    LEFT JOIN post_slides ps ON pp.id = ps.post_id
+    GROUP BY
+      pp.id, pp.created_at, pp.created_by, pp.author_name, pp.content,
+      pp.mood, pp.author_avatar_url, pp.expires_in_24hr, pp.duration,
+      pp.expires_at, pp.downvotes, pp.upvotes, pp.is_sensitive,
+      pp.is_prompt_response, pp.type, pp.author_roles, pp.campfire_id,
+      pp.campfire_name, pp.campfire_slug, pp.campfire_icon_url,
+      pp.priority_score, pp.is_new_post, pp.is_campfire_post,
+      comments_agg.count, views_agg.count
+  )
+  SELECT
+    pwa.id,
+    pwa.created_at,
+    pwa.created_by,
+    pwa.author_name,
+    pwa.content,
+    pwa.mood,
+    pwa.author_avatar_url,
+    pwa.expires_in_24hr,
+    pwa.duration,
+    pwa.expires_at,
+    pwa.downvotes,
+    pwa.upvotes,
+    pwa.is_sensitive,
+    pwa.is_prompt_response,
+    pwa.type,
+    pwa.author_roles,
+    pwa.campfire_id,
+    pwa.campfire_name,
+    pwa.campfire_slug,
+    pwa.campfire_icon_url,
+    pwa.priority_score,
+    pwa.is_new_post,
+    pwa.is_campfire_post,
+    pwa.posttags,
+    pwa.comments_count,
+    pwa.views_count,
+    pwa.collections,
+    pwa.post_slides
+  FROM posts_with_aggregates pwa
+  ORDER BY
+    pwa.priority_score ASC,
+    pwa.created_at DESC
+  LIMIT page_size
+  OFFSET offset_param;
+END;$function$
+;
+
+CREATE OR REPLACE FUNCTION public.get_personalized_feed(user_id_param uuid, page_size integer DEFAULT 50, offset_param integer DEFAULT 0)
+ RETURNS TABLE(id uuid, created_at timestamp with time zone, created_by uuid, author_name text, content text, mood post_mood, author_avatar_url text, expires_in_24hr boolean, duration post_duration, expires_at timestamp with time zone, downvotes integer, upvotes integer, is_sensitive boolean, is_prompt_response boolean, type post_type, author_roles user_role[], campfire_id uuid, campfire_name text, campfire_slug text, campfire_icon_url text, daily_prompt_id uuid, prompt_text text, prompt_category text, priority_score integer, is_new_post boolean, is_campfire_post boolean, posttags jsonb, comments_count bigint, views_count bigint, collections jsonb, post_slides jsonb)
+ LANGUAGE plpgsql
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  new_post_threshold TIMESTAMPTZ := NOW() - INTERVAL '48 hours';
+BEGIN
+  RETURN QUERY
+  WITH user_campfires AS (
+    SELECT cm.campfire_id
+    FROM campfire_members cm
+    WHERE cm.user_id = user_id_param
+  ),
+  prioritized_posts AS (
+    SELECT
+      p.id,
+      p.created_at,
+      p.created_by,
+      p.author_name,
+      p.content,
+      p.mood,
+      p.author_avatar_url,
+      p.expires_in_24hr,
+      p.duration,
+      p.expires_at,
+      p.downvotes,
+      p.upvotes,
+      p.is_sensitive,
+      p.is_prompt_response,
+      p.type,
+      p.author_roles,
+      p.campfire_id,
+      c.name AS campfire_name,
+      c.slug AS campfire_slug,
+      c.icon_url AS campfire_icon_url,
+      p.daily_prompt_id,
+      dp.prompt_text,
+      dp.category AS prompt_category,
+      CASE
+        WHEN p.created_at >= new_post_threshold THEN 1
+        WHEN p.campfire_id IS NOT NULL THEN 2
+        ELSE 3
+      END AS priority_score,
+      (p.created_at >= new_post_threshold) AS is_new_post,
+      (p.campfire_id IS NOT NULL) AS is_campfire_post
+    FROM posts p
+    LEFT JOIN campfires c ON p.campfire_id = c.id
+    LEFT JOIN daily_prompts dp ON p.daily_prompt_id = dp.id
+    WHERE
+      (
+        p.campfire_id IS NULL
+        OR p.campfire_id IN (SELECT uc.campfire_id FROM user_campfires uc)
+      )
+      AND (p.expires_at IS NULL OR p.expires_at > NOW())
+  ),
+  posts_with_aggregates AS (
+    SELECT
+      pp.id,
+      pp.created_at,
+      pp.created_by,
+      pp.author_name,
+      pp.content,
+      pp.mood,
+      pp.author_avatar_url,
+      pp.expires_in_24hr,
+      pp.duration,
+      pp.expires_at,
+      pp.downvotes,
+      pp.upvotes,
+      pp.is_sensitive,
+      pp.is_prompt_response,
+      pp.type,
+      pp.author_roles,
+      pp.campfire_id,
+      pp.campfire_name,
+      pp.campfire_slug,
+      pp.campfire_icon_url,
+      pp.daily_prompt_id,
+      pp.prompt_text,
+      pp.prompt_category,
+      pp.priority_score,
+      pp.is_new_post,
+      pp.is_campfire_post,
+
+      -- Tags
+      COALESCE(
+        (json_agg(DISTINCT jsonb_build_object('name', t.name))
+          FILTER (WHERE t.name IS NOT NULL))::jsonb,
+        '[]'::jsonb
+      ) AS posttags,
+
+      -- Comments count
+      COALESCE(comments_agg.count, 0) AS comments_count,
+
+      -- Views count
+      COALESCE(views_agg.count, 0) AS views_count,
+
+      -- Collections
+      COALESCE(
+        (json_agg(DISTINCT jsonb_build_object('user_id', col.user_id))
+          FILTER (WHERE col.user_id IS NOT NULL))::jsonb,
+        '[]'::jsonb
+      ) AS collections,
+
+      -- Slides
+      COALESCE(
+        (json_agg(
+          jsonb_build_object(
+            'slide_index', ps.slide_index,
+            'content', ps.content
+          ) ORDER BY ps.slide_index
+        ) FILTER (WHERE ps.slide_index IS NOT NULL))::jsonb,
+        '[]'::jsonb
+      ) AS post_slides
+
+    FROM prioritized_posts pp
+    LEFT JOIN posttags pt ON pp.id = pt.post
+    LEFT JOIN tags t ON pt.tag = t.id
+    LEFT JOIN (
+      SELECT post, COUNT(*) AS count
+      FROM comments
+      GROUP BY post
+    ) comments_agg ON pp.id = comments_agg.post
+    LEFT JOIN (
+      SELECT post_id, COUNT(*) AS count
+      FROM views
+      GROUP BY post_id
+    ) views_agg ON pp.id = views_agg.post_id
+    LEFT JOIN collections col ON pp.id = col.post_id
+    LEFT JOIN post_slides ps ON pp.id = ps.post_id
+    GROUP BY
+      pp.id, pp.created_at, pp.created_by, pp.author_name, pp.content,
+      pp.mood, pp.author_avatar_url, pp.expires_in_24hr, pp.duration,
+      pp.expires_at, pp.downvotes, pp.upvotes, pp.is_sensitive,
+      pp.is_prompt_response, pp.type, pp.author_roles, pp.campfire_id,
+      pp.campfire_name, pp.campfire_slug, pp.campfire_icon_url,
+      pp.daily_prompt_id, pp.prompt_text, pp.prompt_category,
+      pp.priority_score, pp.is_new_post, pp.is_campfire_post,
+      comments_agg.count, views_agg.count
+  )
+  SELECT
+    pwa.id,
+    pwa.created_at,
+    pwa.created_by,
+    pwa.author_name,
+    pwa.content,
+    pwa.mood,
+    pwa.author_avatar_url,
+    pwa.expires_in_24hr,
+    pwa.duration,
+    pwa.expires_at,
+    pwa.downvotes,
+    pwa.upvotes,
+    pwa.is_sensitive,
+    pwa.is_prompt_response,
+    pwa.type,
+    pwa.author_roles,
+    pwa.campfire_id,
+    pwa.campfire_name,
+    pwa.campfire_slug,
+    pwa.campfire_icon_url,
+    pwa.daily_prompt_id,
+    pwa.prompt_text,
+    pwa.prompt_category,
+    pwa.priority_score,
+    pwa.is_new_post,
+    pwa.is_campfire_post,
+    pwa.posttags,
+    pwa.comments_count,
+    pwa.views_count,
+    pwa.collections,
+    pwa.post_slides
+  FROM posts_with_aggregates pwa
+  ORDER BY
+    pwa.priority_score ASC,
+    pwa.created_at DESC
+  LIMIT page_size
+  OFFSET offset_param;
+END;
+$function$
+;
+
+
+

--- a/supabase/migrations/20250821001000_update-post-creation-fn.sql
+++ b/supabase/migrations/20250821001000_update-post-creation-fn.sql
@@ -1,0 +1,149 @@
+drop function if exists "public"."create_post_with_tags"(content text, mood post_mood, expires_in_24hr boolean, duration post_duration, expires_at timestamp with time zone, is_sensitive boolean, is_prompt_response boolean, type post_type, tag_names text[], slide_contents text[], campfire_id uuid);
+
+set check_function_bodies = off;
+
+CREATE OR REPLACE FUNCTION public.create_post_with_tags(content text, mood post_mood, expires_in_24hr boolean, duration post_duration DEFAULT NULL::post_duration, expires_at timestamp with time zone DEFAULT NULL::timestamp with time zone, is_sensitive boolean DEFAULT false, is_prompt_response boolean DEFAULT false, type post_type DEFAULT 'single'::post_type, tag_names text[] DEFAULT NULL::text[], slide_contents text[] DEFAULT NULL::text[], campfire_id uuid DEFAULT NULL::uuid, daily_prompt_id uuid DEFAULT NULL::uuid)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SET search_path TO ''
+AS $function$
+DECLARE
+    post_id UUID;
+    tag_id BIGINT;
+    tag_name TEXT;
+    slide_content TEXT;
+    i INTEGER := 1;
+BEGIN
+    -- Insert the post, including daily_prompt_id if provided
+    INSERT INTO public.posts (
+        content,
+        mood,
+        expires_in_24hr,
+        duration,
+        expires_at,
+        is_sensitive,
+        is_prompt_response,
+        type,
+        campfire_id,
+        daily_prompt_id   -- ✅ added
+    )
+    VALUES (
+        content,
+        mood,
+        expires_in_24hr,
+        duration,
+        expires_at,
+        is_sensitive,
+        is_prompt_response,
+        type,
+        campfire_id,
+        daily_prompt_id   -- ✅ added
+    )
+    RETURNING id INTO post_id;
+
+    -- Process and attach tags if provided
+    IF tag_names IS NOT NULL AND array_length(tag_names, 1) > 0 THEN
+        FOREACH tag_name IN ARRAY tag_names LOOP
+            -- Get or create tag
+            INSERT INTO public.tags (name, post)
+            VALUES (tag_name, 1)
+            ON CONFLICT (name) DO UPDATE
+                SET post = tags.post + 1
+            RETURNING id INTO tag_id;
+
+            -- Link tag to post
+            INSERT INTO public.posttags (tag, post)
+            VALUES (tag_id, post_id)
+            ON CONFLICT DO NOTHING;
+        END LOOP;
+    END IF;
+
+    -- If it's a carousel post, save slides
+    IF type = 'carousel' AND slide_contents IS NOT NULL AND array_length(slide_contents, 1) > 0 THEN
+        FOREACH slide_content IN ARRAY slide_contents LOOP
+            INSERT INTO public.post_slides (post_id, slide_index, content)
+            VALUES (post_id, i - 1, slide_content);
+            i := i + 1;
+        END LOOP;
+    END IF;
+
+    RETURN post_id;
+
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE EXCEPTION 'Failed to create post: %', SQLERRM;
+END;
+$function$
+;
+
+CREATE OR REPLACE FUNCTION public.create_post_with_tags_v6(content text, mood post_mood, expires_in_24hr boolean, duration post_duration DEFAULT NULL::post_duration, expires_at timestamp with time zone DEFAULT NULL::timestamp with time zone, is_sensitive boolean DEFAULT false, is_prompt_response boolean DEFAULT false, type post_type DEFAULT 'single'::post_type, tag_names text[] DEFAULT NULL::text[], slide_contents text[] DEFAULT NULL::text[], campfire_id uuid DEFAULT NULL::uuid)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SET search_path TO ''
+AS $function$DECLARE
+    post_id UUID;
+    tag_id BIGINT;
+    tag_name TEXT;
+    slide_content TEXT;
+    i INTEGER := 1;
+BEGIN
+    -- Insert the post
+    INSERT INTO public.posts (
+        content,
+        mood,
+        expires_in_24hr,
+        duration,
+        expires_at,
+        is_sensitive,
+        is_prompt_response,
+        type,
+        campfire_id
+    )
+    VALUES (
+        content,
+        mood,
+        expires_in_24hr,
+        duration,        -- This will now be NULL if not provided
+        expires_at,      -- This will now be NULL if not provided
+        is_sensitive,
+        is_prompt_response,
+        type,
+        campfire_id
+    )
+    RETURNING id INTO post_id;
+
+    -- Process and attach tags if provided
+    IF tag_names IS NOT NULL AND array_length(tag_names, 1) > 0 THEN
+        FOREACH tag_name IN ARRAY tag_names LOOP
+            -- Get or create tag
+            INSERT INTO public.tags (name, post)
+            VALUES (tag_name, 1)
+            ON CONFLICT (name) DO UPDATE
+            SET post = tags.post + 1
+            RETURNING id INTO tag_id;
+
+            -- Link tag to post
+            INSERT INTO public.posttags (tag, post)
+            VALUES (tag_id, post_id)
+            ON CONFLICT DO NOTHING;
+        END LOOP;
+    END IF;
+
+    -- If it's a carousel post, save slides
+    IF type = 'carousel' AND slide_contents IS NOT NULL AND array_length(slide_contents, 1) > 0 THEN
+        FOREACH slide_content IN ARRAY slide_contents LOOP
+            INSERT INTO public.post_slides (post_id, slide_index, content)
+            VALUES (post_id, i - 1, slide_content);
+            i := i + 1;
+        END LOOP;
+    END IF;
+
+    RETURN post_id;
+EXCEPTION
+    WHEN OTHERS THEN
+        RAISE EXCEPTION 'Failed to create post: %', SQLERRM;
+END;$function$
+;
+
+
+

--- a/types/types_db.d.ts
+++ b/types/types_db.d.ts
@@ -427,6 +427,7 @@ export type Database = {
         Row: {
           author_avatar_url: string | null
           author_name: string | null
+          campfire_id: string | null
           comment_text: string
           created_at: string
           created_by: string | null
@@ -439,6 +440,7 @@ export type Database = {
         Insert: {
           author_avatar_url?: string | null
           author_name?: string | null
+          campfire_id?: string | null
           comment_text: string
           created_at?: string
           created_by?: string | null
@@ -451,6 +453,7 @@ export type Database = {
         Update: {
           author_avatar_url?: string | null
           author_name?: string | null
+          campfire_id?: string | null
           comment_text?: string
           created_at?: string
           created_by?: string | null
@@ -461,6 +464,13 @@ export type Database = {
           post?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "comments_campfire_id_fkey"
+            columns: ["campfire_id"]
+            isOneToOne: false
+            referencedRelation: "campfires"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "comments_created_by_fkey"
             columns: ["created_by"]
@@ -487,6 +497,7 @@ export type Database = {
       daily_prompts: {
         Row: {
           active_on: string
+          category: string
           created_at: string
           created_by: string
           id: string
@@ -495,6 +506,7 @@ export type Database = {
         }
         Insert: {
           active_on: string
+          category?: string
           created_at?: string
           created_by: string
           id?: string
@@ -503,6 +515,7 @@ export type Database = {
         }
         Update: {
           active_on?: string
+          category?: string
           created_at?: string
           created_by?: string
           id?: string
@@ -877,6 +890,7 @@ export type Database = {
           content: string
           created_at: string
           created_by: string | null
+          daily_prompt_id: string | null
           downvotes: number
           duration: Database["public"]["Enums"]["post_duration"] | null
           expires_at: string | null
@@ -896,6 +910,7 @@ export type Database = {
           content: string
           created_at?: string
           created_by?: string | null
+          daily_prompt_id?: string | null
           downvotes?: number
           duration?: Database["public"]["Enums"]["post_duration"] | null
           expires_at?: string | null
@@ -915,6 +930,7 @@ export type Database = {
           content?: string
           created_at?: string
           created_by?: string | null
+          daily_prompt_id?: string | null
           downvotes?: number
           duration?: Database["public"]["Enums"]["post_duration"] | null
           expires_at?: string | null
@@ -939,6 +955,13 @@ export type Database = {
             columns: ["created_by"]
             isOneToOne: false
             referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+          {
+            foreignKeyName: "posts_daily_prompt_id_fkey"
+            columns: ["daily_prompt_id"]
+            isOneToOne: false
+            referencedRelation: "daily_prompts"
             referencedColumns: ["id"]
           },
         ]
@@ -1690,6 +1713,7 @@ export type Database = {
         Returns: {
           author_avatar_url: string | null
           author_name: string | null
+          campfire_id: string | null
           comment_text: string
           created_at: string
           created_by: string | null
@@ -1720,6 +1744,46 @@ export type Database = {
         }[]
       }
       get_personalized_feed: {
+        Args: {
+          user_id_param: string
+          page_size?: number
+          offset_param?: number
+        }
+        Returns: {
+          id: string
+          created_at: string
+          created_by: string
+          author_name: string
+          content: string
+          mood: Database["public"]["Enums"]["post_mood"]
+          author_avatar_url: string
+          expires_in_24hr: boolean
+          duration: Database["public"]["Enums"]["post_duration"]
+          expires_at: string
+          downvotes: number
+          upvotes: number
+          is_sensitive: boolean
+          is_prompt_response: boolean
+          type: Database["public"]["Enums"]["post_type"]
+          author_roles: Database["public"]["Enums"]["user_role"][]
+          campfire_id: string
+          campfire_name: string
+          campfire_slug: string
+          campfire_icon_url: string
+          daily_prompt_id: string
+          prompt_text: string
+          prompt_category: string
+          priority_score: number
+          is_new_post: boolean
+          is_campfire_post: boolean
+          posttags: Json
+          comments_count: number
+          views_count: number
+          collections: Json
+          post_slides: Json
+        }[]
+      }
+      get_personalized_feed_v1: {
         Args: {
           user_id_param: string
           page_size?: number

--- a/types/types_db.d.ts
+++ b/types/types_db.d.ts
@@ -1627,6 +1627,7 @@ export type Database = {
           tag_names?: string[]
           slide_contents?: string[]
           campfire_id?: string
+          daily_prompt_id?: string
         }
         Returns: string
       }
@@ -1692,6 +1693,22 @@ export type Database = {
           type?: Database["public"]["Enums"]["post_type"]
           tag_names?: string[]
           slide_contents?: string[]
+        }
+        Returns: string
+      }
+      create_post_with_tags_v6: {
+        Args: {
+          content: string
+          mood: Database["public"]["Enums"]["post_mood"]
+          expires_in_24hr: boolean
+          duration?: Database["public"]["Enums"]["post_duration"]
+          expires_at?: string
+          is_sensitive?: boolean
+          is_prompt_response?: boolean
+          type?: Database["public"]["Enums"]["post_type"]
+          tag_names?: string[]
+          slide_contents?: string[]
+          campfire_id?: string
         }
         Returns: string
       }


### PR DESCRIPTION
Added support for passing daily prompt parameters to the post creation flow, including handling of prompt text and prompt ID. Improved draft saving logic to avoid saving unmodified prompt responses. Updated types and RPC call to support daily_prompt_id. Also included campfire_id in comment mutation for consistency.