### PR TITLE
Add onboarding campfire join flow to welcome modal

### DIFF
--- a/components/cards/OnboardingCampfireCard.tsx
+++ b/components/cards/OnboardingCampfireCard.tsx
@@ -1,0 +1,77 @@
+import { Button } from '@/components/ui/button';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Loader2 } from 'lucide-react';
+
+interface Campfire {
+  campfireId: string;
+  name: string;
+  slug: string;
+  description: string;
+  members: number;
+  iconURL?: string;
+  isMember: boolean;
+}
+
+interface CampfireCardProps {
+  campfire: Campfire;
+  isJoining: boolean;
+  onJoin: (campfireId: string) => void;
+}
+
+export default function OnboardingCampfireCard({
+  campfire,
+  isJoining,
+  onJoin,
+}: CampfireCardProps) {
+  const { campfireId, name, description, members, iconURL, isMember } = campfire;
+
+  return (
+    <div className="flex items-start justify-between gap-3 rounded-lg shadow dark:shadow-none border dark:border-gray-700 bg-white dark:bg-gray-800/50 p-4 transition-all dark:hover:border-gray-600 dark:hover:bg-gray-800/70">
+      <div className="flex min-w-0 flex-1 gap-3">
+        <Avatar className="h-10 w-10 flex-shrink-0">
+          <AvatarImage src={iconURL} alt={name} />
+          <AvatarFallback className="border-lavender-500 flex h-10 w-10 items-center justify-center rounded-full border font-semibold text-white">
+            <span className="bg-lavender-500 flex h-9 w-9 items-center justify-center rounded-full font-semibold text-white">
+              x/
+            </span>
+          </AvatarFallback>
+        </Avatar>
+
+        <div className="flex min-w-0 flex-col">
+          <h4 className="truncate font-semibold dark:text-white">{name}</h4>
+          <p className="line-clamp-2 text-sm text-gray-500 dark:text-gray-400">{description}</p>
+          <p className="mt-1 text-xs dark:text-gray-500">{members} members</p>
+        </div>
+      </div>
+
+      <div className="flex-shrink-0">
+        {isMember ? (
+          <Button
+            size="sm"
+            variant="outline"
+            className="h-8 rounded-full border-gray-600 px-3 text-xs text-gray-400"
+            disabled
+          >
+            Joined
+          </Button>
+        ) : (
+          <Button
+            size="sm"
+            onClick={() => onJoin(campfireId)}
+            disabled={isJoining}
+            className="h-8 rounded-full bg-indigo-600 px-3 text-xs hover:bg-indigo-700"
+          >
+            {isJoining ? (
+              <>
+                <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                Joining...
+              </>
+            ) : (
+              'Join'
+            )}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/modals/JoinCampfireStep.tsx
+++ b/components/modals/JoinCampfireStep.tsx
@@ -71,7 +71,7 @@ export default function JoinCampfiresStep({
         </AlertDialogDescription>
         {isAnon && (
           <AlertDialogDescription className="text-center text-gray-500 dark:text-gray-300">
-           <span className="font-medium text-amber-400">NB:</span> Anonymous users can't join campfires.
+           <span className="font-medium text-amber-400">NB:</span> Anonymous users can&apos;t join campfires.
           </AlertDialogDescription>
         )}
         </>

--- a/components/modals/JoinCampfireStep.tsx
+++ b/components/modals/JoinCampfireStep.tsx
@@ -1,0 +1,125 @@
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { ChevronLeft, ExternalLink } from 'lucide-react';
+import Link from 'next/link';
+import OnboardingCampfireCard from '../cards/OnboardingCampfireCard';
+import OnboardingCampfireCardSkeleton from '../shared/loaders/OnboardingCampfireCardSkeleton';
+import { useRouter } from 'next/navigation';
+
+interface Campfire {
+  campfireId: string;
+  name: string;
+  slug: string;
+  description: string;
+  members: number;
+  iconURL?: string;
+  isMember: boolean;
+}
+
+interface JoinCampfiresStepProps {
+  publicCampfires?: Campfire[];
+  isLoadingCampfires: boolean;
+  joiningCampfireId: string | null;
+  hasJoinedCampfire: boolean;
+  onJoinCampfire: (campfireId: string) => void;
+  onBack: () => void;
+  onFinish: () => void;
+  isAnon: boolean | undefined;
+}
+
+export default function JoinCampfiresStep({
+  publicCampfires,
+  isLoadingCampfires,
+  joiningCampfireId,
+  hasJoinedCampfire,
+  onJoinCampfire,
+  onBack,
+  onFinish,
+  isAnon,
+}: JoinCampfiresStepProps) {
+  const router = useRouter();
+
+  const handleExplore = () => {
+    onFinish();
+    router.push('/campfires/discover');
+  };
+  return (
+    <>
+      <AlertDialogHeader>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onBack}
+            className="h-8 w-8 text-gray-400 hover:text-gray-300"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </Button>
+          <AlertDialogTitle className="flex-1 text-center text-2xl font-bold">
+            Join Your First Campfires 🔥
+          </AlertDialogTitle>
+          <div className="w-8" /> {/* Spacer for centering */}
+        </div>
+        <>
+        <AlertDialogDescription className="text-center text-gray-500 dark:text-gray-300">
+          Get started by joining campfires that match your interests.
+        </AlertDialogDescription>
+        {isAnon && (
+          <AlertDialogDescription className="text-center text-gray-500 dark:text-gray-300">
+           <span className="font-medium text-amber-400">NB:</span> Anonymous users can't join campfires.
+          </AlertDialogDescription>
+        )}
+        </>
+      </AlertDialogHeader>
+
+      <div className="max-h-[400px] space-y-3 overflow-y-auto py-4">
+        {isLoadingCampfires ? (
+          <div className="flex flex-col gap-3">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <OnboardingCampfireCardSkeleton key={i} />
+            ))}
+          </div>
+        ) : publicCampfires && publicCampfires.length > 0 ? (
+          publicCampfires.map(campfire => (
+            <OnboardingCampfireCard
+              key={campfire.campfireId}
+              campfire={campfire}
+              isJoining={joiningCampfireId === campfire.campfireId}
+              onJoin={onJoinCampfire}
+            />
+          ))
+        ) : (
+          <div className="py-8 text-center text-gray-400">
+            <p>No campfires available at the moment.</p>
+            <p className="mt-2 text-sm">Check back later!</p>
+          </div>
+        )}
+      </div>
+
+      <AlertDialogFooter className="flex-col gap-2 sm:flex-col">
+        <Button
+          onClick={onFinish}
+          disabled={!hasJoinedCampfire || isAnon}
+          className="w-full bg-indigo-600 text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {hasJoinedCampfire
+            ? "I'm ready to share!"
+            : 'Join at least one campfire to continue'}
+        </Button>
+        <Button
+          onClick={handleExplore}
+          variant="ghost"
+          className="w-full text-gray-500 dark:text-gray-400 hover:text-gray-400 dark:hover:text-gray-300"
+        >
+          Explore all campfires
+            <ExternalLink className="ml-2 h-4 w-4" />
+          </Button>
+      </AlertDialogFooter>
+    </>
+  );
+}

--- a/components/modals/WelcomeStep.tsx
+++ b/components/modals/WelcomeStep.tsx
@@ -1,0 +1,76 @@
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { HeartHandshake, Zap, Medal, ChevronRight } from 'lucide-react';
+
+interface WelcomeStepProps {
+  onNext: () => void;
+  onSkip: () => void;
+  isAnon: boolean | undefined;
+  onFinish: () => void;
+  hasJoinedCampfire: boolean;
+}
+
+export default function WelcomeStep({ onNext, onSkip, isAnon, onFinish, hasJoinedCampfire }: WelcomeStepProps) {
+  return (
+    <>
+      <AlertDialogHeader>
+        <AlertDialogTitle className="text-center text-2xl font-bold">
+          You&apos;re Early and Essential! 🚀
+        </AlertDialogTitle>
+        <AlertDialogDescription className="text-center text-gray-500 dark:text-gray-300">
+          <span className="text-lavender-500">Welcome to Xolace 🎉</span>, and
+          thank you for being part of the few hundreds shaping Xolace&apos;s
+          future.
+        </AlertDialogDescription>
+      </AlertDialogHeader>
+      <div className="py-4">
+        <div className="flex items-start gap-2 dark:text-gray-300">
+          <Medal className="text-ocean-400 mt-1 h-5 w-5 flex-shrink-0" />
+          <p>
+            <span className="font-medium text-purple-400 dark:text-purple-300">
+              Early adopters like you
+            </span>{' '}
+            will define what this space becomes. We can&apos;t wait to see
+            what you&apos;ll share.
+          </p>
+        </div>
+        <div className="mb-4 flex items-start gap-2 dark:text-gray-300">
+          <HeartHandshake className="mt-1 h-5 w-5 flex-shrink-0 text-pink-400" />
+          <p>
+            At <span className="text-ocean-500 dark:text-ocean-300">Xolace</span>, we believe
+            someone out there needs your story just as much as you need to
+            tell it. Share your journey and help us grow something meaningful
+            together.
+          </p>
+        </div>
+        <div className="rounded-lg border  bg-gray-200 p-3 dark:border-purple-500 dark:bg-gray-800/50">
+          <div className="flex items-center gap-2 text-sm text-purple-400 dark:text-purple-300">
+            <Zap className="h-4 w-4" />
+            <span>Early adopter perks coming soon</span>
+          </div>
+        </div>
+      </div>
+      <AlertDialogFooter className="flex-col gap-2 sm:flex-col">
+        <Button
+          onClick={onNext}
+          className="w-full bg-indigo-600 text-white hover:bg-indigo-700"
+        >
+          Continue
+          <ChevronRight className="ml-2 h-4 w-4" />
+        </Button>
+        <Button
+          onClick={isAnon || hasJoinedCampfire ? onFinish : onSkip}
+          variant="ghost"
+          className={`w-full ${isAnon || hasJoinedCampfire ? 'text-red-400 hover:text-red-300' : 'text-gray-400 hover:text-gray-500 dark:hover:text-gray-300'}`}
+        >
+         {isAnon || hasJoinedCampfire ? 'Close' : 'Skip to join campfires'}
+        </Button>
+      </AlertDialogFooter>
+    </>
+  );
+}

--- a/components/shared/loaders/OnboardingCampfireCardSkeleton.tsx
+++ b/components/shared/loaders/OnboardingCampfireCardSkeleton.tsx
@@ -1,0 +1,15 @@
+export default function OnboardingCampfireCardSkeleton() {
+    return (
+      <div className="flex animate-pulse items-start justify-between gap-3 rounded-lg border border-gray-700 bg-gray-800/50 p-4">
+        <div className="flex flex-1 gap-3">
+          <div className="h-10 w-10 flex-shrink-0 rounded-full bg-gray-700" />
+          <div className="flex min-w-0 flex-1 flex-col gap-2">
+            <div className="h-4 w-32 rounded bg-gray-700" />
+            <div className="h-3 w-full rounded bg-gray-700" />
+            <div className="h-3 w-20 rounded bg-gray-700" />
+          </div>
+        </div>
+        <div className="h-8 w-16 rounded-full bg-gray-700" />
+      </div>
+    );
+  }

--- a/hooks/campfires/useJoinCampfireMutation.ts
+++ b/hooks/campfires/useJoinCampfireMutation.ts
@@ -52,6 +52,8 @@ export function useJoinCampfireMutation() {
       toast.success('Successfully joined campfire!');
       queryClient.invalidateQueries({ queryKey: ['campfires', 'user', 'joined', user?.id] });
       queryClient.invalidateQueries({ queryKey: ['campfires', 'user', 'favorites', user?.id] });
+      queryClient.invalidateQueries({ queryKey: ['campfires', 'public', 'feed'] });
+      queryClient.invalidateQueries({ queryKey: ['campfires', 'user', user?.id, 'count'] });
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: ['campfires', 'public'] });

--- a/hooks/campfires/useLeaveCampfireMutation.ts
+++ b/hooks/campfires/useLeaveCampfireMutation.ts
@@ -81,11 +81,14 @@ export function useLeaveCampfireMutation() {
       }
 
       // Show err.message when it is Firestarters cannot leave their campfire. Transfer ownership first. or general message
-      if (err.message === 'Firestarters cannot leave their campfire. Transfer ownership first.') {
+      if (
+        err.message ===
+        'Firestarters cannot leave their campfire. Transfer ownership first.'
+      ) {
         toast.error(err.message);
         return;
       }
-      toast.error("Failed to leave campfire. Please try again.");
+      toast.error('Failed to leave campfire. Please try again.');
     },
     onSuccess: (_, campfireId) => {
       toast.success(
@@ -96,6 +99,11 @@ export function useLeaveCampfireMutation() {
       queryClient.invalidateQueries({
         queryKey: ['campfires', 'public', campfireId],
       });
+
+      queryClient.invalidateQueries({
+        queryKey: ['campfires', 'public', 'feed'],
+      });
+
       queryClient.invalidateQueries({
         queryKey: ['campfire', 'members', campfireId],
       });
@@ -105,6 +113,10 @@ export function useLeaveCampfireMutation() {
       });
       queryClient.invalidateQueries({
         queryKey: ['campfires', 'user', 'favorites', user?.id],
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: ['campfires', 'user', user?.id, 'count'],
       });
     },
     onSettled: () => {

--- a/queries/campfires/getLimitedPublicCampfies.ts
+++ b/queries/campfires/getLimitedPublicCampfies.ts
@@ -1,0 +1,85 @@
+import { useQuery } from '@tanstack/react-query';
+import { getSupabaseBrowserClient } from '@/utils/supabase/client';
+import { CampfirePurpose } from '@/components/campfires/campfires.types';
+
+export interface Campfire {
+  campfireId: string;
+  name: string;
+  slug: string;
+  description: string;
+  members: number;
+  purpose: CampfirePurpose;
+  iconURL?: string;
+  isMember: boolean;
+}
+
+const QUERY_STALE_TIME = 5 * 60 * 1000; // 5 minutes
+const QUERY_CACHE_TIME = 10 * 60 * 1000; // 10 minutes
+
+export function getLimitedPublicCampfires(userId?: string) {
+  const supabase = getSupabaseBrowserClient();
+
+  return useQuery<Campfire[], Error>({
+    queryKey: ['campfires', 'public', 'feed'],
+    queryFn: async () => {
+      // @ts-ignore
+      const { data, error } = await supabase
+        .from('campfires')
+        .select(
+          `
+          id,
+          name,
+          slug,
+          description,
+          member_count,
+          purpose,
+          icon_url,
+          campfire_members!left(user_id)
+        `,
+        )
+        .eq('visibility', 'public')
+        .limit(5)
+        .order('member_count', { ascending: false });
+
+      if (error) {
+        console.error('Error fetching public campfires:', error);
+        throw new Error(error.message);
+      }
+
+      if (!data) {
+        return [];
+      }
+
+      // The type assertion is needed here because the dynamic select with join
+      // isn't fully typed by Supabase's generator. We are confident in the shape
+      // of the data we are receiving from our query.
+      const typedData = data as unknown as Array<{
+        id: string;
+        name: string;
+        slug: string;
+        description: string | null;
+        member_count: number;
+        purpose: CampfirePurpose;
+        icon_url: string | null;
+        campfire_members: Array<{ user_id: string }>;
+      }>;
+
+      return typedData.map(campfire => ({
+        campfireId: campfire.id,
+        name: campfire.name,
+        slug: campfire.slug,
+        description: campfire.description || '',
+        members: campfire.member_count,
+        purpose: campfire.purpose,
+        iconURL: campfire.icon_url || undefined,
+        isMember: userId
+          ? campfire.campfire_members.some(m => m.user_id === userId)
+          : false,
+      }));
+    },
+    staleTime: QUERY_STALE_TIME,
+    gcTime: QUERY_CACHE_TIME,
+    enabled: !!userId,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/queries/users/useUserCampfireCount.ts
+++ b/queries/users/useUserCampfireCount.ts
@@ -1,0 +1,32 @@
+// get user camfire count with react query
+
+import { useQuery } from '@tanstack/react-query';
+import { getSupabaseBrowserClient } from '@/utils/supabase/client';
+
+const QUERY_STALE_TIME = 60 * 60 * 1000; // 1 hour
+
+export const useUserCampfireCount = (userId?: string) => {
+  const supabase = getSupabaseBrowserClient();
+
+  return useQuery({
+    queryKey: ['campfires', 'user', userId, 'count'],
+    queryFn: async () => {
+      if (!userId) return 0;
+
+      const { count, error } = await supabase
+        .from('campfire_members')
+        .select('*', { count: 'exact', head: true })
+        .eq('user_id', userId);
+
+      if (error) {
+        console.error('Error fetching user campfire count:', error);
+        throw new Error(error.message);
+      }
+
+      return count || 0;
+    },
+    staleTime: QUERY_STALE_TIME,
+    enabled: !!userId,
+    refetchOnWindowFocus: false,
+  });
+};


### PR DESCRIPTION
Introduces a multi-step onboarding experience in the welcome modal, prompting new users to join campfires before proceeding. Adds new components for onboarding campfire cards, skeleton loaders, and modal steps. Implements queries and hooks to fetch public campfires and user campfire count, and updates mutation hooks to properly invalidate related queries. Refactors WelcomeModalCard to support step navigation and confetti animation on completion.